### PR TITLE
Style fixes

### DIFF
--- a/instapups/src/sass/Modules/Post.modules.scss
+++ b/instapups/src/sass/Modules/Post.modules.scss
@@ -12,7 +12,7 @@
   //overflow: hidden;
   top: 0;
   left: 0;
-  border-top: 1px solid #bcb4cf;
+  border-bottom: 1px solid #bcb4cf;
 
 .link-to-Member {
   text-decoration: none;

--- a/instapups/src/sass/Modules/Sidemenu.modules.scss
+++ b/instapups/src/sass/Modules/Sidemenu.modules.scss
@@ -14,9 +14,6 @@
     width: 50px;
     height: 100%;
   }
-    
-  }
-  
 
   @include nav-button;
 
@@ -37,3 +34,8 @@
   }
 
 
+    
+  }
+  
+
+ 


### PR DESCRIPTION
- A couple of curly braces were misplaced so side-menu-button-styling ended up affecting all buttons. Nested the menu-button-styling inside its parent and removed a curly brace, so now it's back to normal.
- Switched from border-top to border-bottom on posts