### PR TITLE
Improved feed load on own profile after switching

### DIFF
--- a/instapups/src/Pages/Member.js
+++ b/instapups/src/Pages/Member.js
@@ -89,7 +89,7 @@ const Member = () => {
 
         <div className='memberPage'>
         { member.username === loggedInUser.username ? <OwnProfileCard loggedInUser={loggedInUser} posts={posts} /> : <UserCard member={member} following={isFollowing} posts={posts} onFollowUnfollow={handleFollowUnfollow} />}
-        { loaded ? (!isFollowing ? <p> {followMessage} </p> : (!gotPosts ? <p> {postMessage} </p> :  ( posts.map((post) => (<Post key={post._id} {...post} onEditSubmit={handleEditPost}/>))))) : ( "Loading..." ) }
+        { loaded ? member.username === loggedInUser.username ? posts.map((post) => (<Post key={post._id} {...post} onEditSubmit={handleEditPost}/>)) : (!isFollowing ? <p> {followMessage} </p> : (!gotPosts ? <p> {postMessage} </p> :  ( posts.map((post) => (<Post key={post._id} {...post} onEditSubmit={handleEditPost}/>))))) : ( "Loading..." ) }
         </div>
 
         <div></div>


### PR DESCRIPTION
- Ones' own posts weren't loading on the users own profile IF they had previously visited a user either without any posts, or someone who the user wasn't following. It got stuck on the previous response and stopped showing the own profile. So I added an extra double check to the ternary operator to load posts on the users own profile no matter what.